### PR TITLE
Select and Order to append columns

### DIFF
--- a/select.go
+++ b/select.go
@@ -69,7 +69,7 @@ func (sb *SelectBuilder) Distinct() *SelectBuilder {
 
 // Select sets columns in SELECT.
 func (sb *SelectBuilder) Select(col ...string) *SelectBuilder {
-	sb.selectCols = col
+	sb.selectCols = append(sb.selectCols, col)
 	return sb
 }
 
@@ -124,7 +124,7 @@ func (sb *SelectBuilder) GroupBy(col ...string) *SelectBuilder {
 
 // OrderBy sets columns of ORDER BY in SELECT.
 func (sb *SelectBuilder) OrderBy(col ...string) *SelectBuilder {
-	sb.orderByCols = col
+	sb.orderByCols = append(sb.orderByCols, col)
 	return sb
 }
 


### PR DESCRIPTION
- when calling either select or order by on the same object the
expectation is to add to the current select statement not to wipe it.

Signed-off-by: Bishoy Youssef <byoussef@pivotal.io>